### PR TITLE
feature/improve server side streaming support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
         run: echo "${{ secrets.DOCKER_TOKEN }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Docker publish
-        run: 'docker buildx build -t touchdown/gyremock:0.4.2 --platform linux/amd64,linux/arm64 --push .'
+        run: 'docker buildx build -t touchdown/gyremock:0.4.3 --platform linux/amd64,linux/arm64 --push .'

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "gyremock"
 
-version := "0.4.2"
+version := "0.4.3"
 
 scalaVersion := "2.13.10"
 

--- a/project/AkkaRedirectCodeGen.scala
+++ b/project/AkkaRedirectCodeGen.scala
@@ -55,7 +55,7 @@ final private class RedirectCodeGenerator(service: Service) {
         case akka.grpc.gen.Unary =>
           s"""httpMock.send[${method.parameterType}, ${method.outputTypeUnboxed}](in, "/${service.name}/${method.name}")"""
         case akka.grpc.gen.ServerStreaming =>
-          s"""Source.future(httpMock.send[${method.parameterType}, ${method.outputTypeUnboxed}](in, "/${service.name}/${method.name}"))"""
+          s"""Source.future(httpMock.sendStream[${method.parameterType}, ${method.outputTypeUnboxed}](in, "/${service.name}/${method.name}")).mapConcat(identity)"""
         case akka.grpc.gen.ClientStreaming =>
           s"""in.runWith(Sink.last).flatMap(e => httpMock.send[${method.inputTypeUnboxed}, ${method.outputTypeUnboxed}](e, "/${service.name}/${method.name}"))"""
         case akka.grpc.gen.BidiStreaming =>

--- a/src/main/scala/dev/touchdown/gyremock/HttpMock.scala
+++ b/src/main/scala/dev/touchdown/gyremock/HttpMock.scala
@@ -7,13 +7,15 @@ import java.net.http.HttpResponse
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Success, Try}
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer
 import com.typesafe.scalalogging.StrictLogging
+import org.json4s.JsonAST
+import org.json4s.jackson.JsonMethods
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 import scalapb.json4s.{Parser, Printer}
 
@@ -52,6 +54,37 @@ class HttpMock(settings: WiremockSettings, jsPrinter: Printer, jsParser: Parser)
             m => logger.info("resp proto:\n{}", m.toProtoString)
           )
           resp.get
+      }
+  }
+
+  def sendStream[I <: GeneratedMessage, O <: GeneratedMessage: GeneratedMessageCompanion](message: I, path: String)(
+    implicit ec: ExecutionContext
+  ): Future[List[O]] = {
+    val json = jsPrinter.print(message)
+    logger.info("received raw message:\n{}\njson:\n{}", message.toProtoString, json)
+    val request = HttpRequest.newBuilder
+      .uri(URI.create(targetBaseUrl + path))
+      .POST(HttpRequest.BodyPublishers.ofString(json))
+      .build
+    HttpClient.newHttpClient
+      .sendAsync(request, HttpResponse.BodyHandlers.ofString)
+      .toScala
+      .map {
+        r =>
+          val js = JsonMethods
+            .parse(r.body()) match {
+            case JsonAST.JArray(arr) => arr
+            case j                   => List(j)
+          }
+          js.map {
+            jValue =>
+              val resp = Try(jsParser.fromJson[O](jValue))
+              resp.fold(
+                ex => logger.error("failed to parse into protos", ex),
+                m => logger.info("resp proto:\n{}", m.toProtoString)
+              )
+              resp.get
+          }
       }
   }
 }


### PR DESCRIPTION
currently gyremock has some issues when mocking server side streaming responses.
the current example might not be correct:
```
message TransactionResponse {
  uint64 id = 1;
  // other fields
}
message SearchTransactionResponse {
  repeated TransactionResponse transactions = 1;
}
service WalletService {
  rpc searchTransaction (SearchTransactionRequest) returns (stream SearchTransactionResponse) {}
}
```
usually we do not use streaming API in this way, but may like:
```
rpc searchTransaction (SearchTransactionRequest) returns (stream TransactionResponse) {}
```
or
```
// just a simple wrapper
message SearchTransactionResponse {
  TransactionResponse transactions = 1; // single item here
}
rpc searchTransaction (SearchTransactionRequest) returns (stream SearchTransactionResponse) {}
```
so we should support Arrays in the mock JSON file instead of Objects.

this pr is to add supporting for Arrays in the mock JSON file, and keep the back compatibility for the old ones.
