### PR TITLE
update com.thesamet.scalapb.scalapb-json4s to 0.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val runtime = Project(id = gyremockRuntimeName, base = file("runtime"))
       "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % akkaGrpcVersion,
       "com.typesafe.akka" %% "akka-actor" % "2.6.20",
       "com.typesafe.akka" %% "akka-http-core" % "10.2.9",
-      "com.thesamet.scalapb" %% "scalapb-json4s" % "0.11.1",
+      "com.thesamet.scalapb" %% "scalapb-json4s" % "0.12.1",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "org.wiremock" % "wiremock" % "3.3.1",
       "org.scalatest" %% "scalatest" % "3.1.0" % Test


### PR DESCRIPTION
`0.11.1` uses json4s-core `3.6.11`; it is too old to be forward-compatible. We need to `4.0.6` in our projects.

The method is removed in `4.0.6`

```
java.lang.NoSuchMethodError: 'org.json4s.JsonInput org.json4s.package$.string2JsonInput(java.lang.String)'
        at io.github.touchdown.gyremock.GrpcFromToJsonImpl.parseResp(GrpcFromToJson.scala:55)
```