### PR TITLE
updated sbt version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ inThisBuild(
     homepage := Some(url("https://github.com/touchdown/gyremock")),
     // Alternatively License.Apache2 see https://github.com/sbt/librarymanagement/blob/develop/core/src/main/scala/sbt/librarymanagement/License.scala
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-    developers := List(Developer("touchdown", "Tony Zhao", "daodetony@gmail.com", url("https://github.com/touchdown")))
+    developers := List(Developer("touchdown", "Tony Zhao", "", url("https://github.com/touchdown")))
   )
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.6


### PR DESCRIPTION
> Note: Sonatype has [sunset the Legacy OSSRH endpoint to publish](https://central.sonatype.org/news/20250326_ossrh_sunset/) on 2025-06-30. To publish to the Central Repository, please migrate to sbt 1.11.x or later and sbt-ci-release 1.11.0 or later after you migrate to publish to the Central Portal publishing.